### PR TITLE
Add test to validate probes are properly parsed with inline processes

### DIFF
--- a/internal/models/cf_types.go
+++ b/internal/models/cf_types.go
@@ -50,6 +50,7 @@ type AppManifest struct {
 	Stack              string                `yaml:"stack,omitempty"`
 	Metadata           *AppMetadata          `yaml:"metadata,omitempty"`
 	AppManifestProcess `yaml:",inline"`
+	Path               string `yaml:"path,omitempty"`
 }
 
 type AppManifestProcesses []AppManifestProcess

--- a/internal/models/cf_types.go
+++ b/internal/models/cf_types.go
@@ -148,7 +148,7 @@ type AppManifestSideCar struct {
 	Name         string           `yaml:"name"`
 	ProcessTypes []AppProcessType `yaml:"process_types,omitempty"`
 	Command      string           `yaml:"command,omitempty"`
-	Memory       int              `yaml:"memory,omitempty"`
+	Memory       string           `yaml:"memory,omitempty"`
 }
 
 func NewCloudFoundryManifest(space string, applications ...*AppManifest) *CloudFoundryManifest {

--- a/pkg/providers/discoverers/cloud_foundry/mocks.go
+++ b/pkg/providers/discoverers/cloud_foundry/mocks.go
@@ -274,11 +274,17 @@ func (m *mockApplication) sidecars() []string {
 		pt := toJSON(v.ProcessTypes)
 		sptypes := []string{}
 		Expect(json.Unmarshal([]byte(pt), &sptypes)).ToNot(HaveOccurred())
+		var mem int
+		var err error
+		if len(v.Memory) > 0 {
+			mem, err = strconv.Atoi(v.Memory)
+			Expect(err).NotTo(HaveOccurred())
+		}
 		sc := resource.Sidecar{
 			Name:         v.Name,
 			Command:      v.Command,
 			ProcessTypes: sptypes,
-			MemoryInMB:   v.Memory,
+			MemoryInMB:   mem,
 			Origin:       "user",
 		}
 		sidecars = append(sidecars, toJSON(sc))

--- a/pkg/providers/discoverers/cloud_foundry/parser.go
+++ b/pkg/providers/discoverers/cloud_foundry/parser.go
@@ -223,7 +223,7 @@ var parseCFApp = func(spaceName string, cfApp cfTypes.AppManifest) (Application,
 			return Application{}, err
 		}
 		if t != nil {
-			app.ProcessSpecTemplate = *t
+			app.ProcessSpecTemplate = t
 		}
 	} else {
 		inlineProcess, err := parseProcessInline(cfApp)

--- a/pkg/providers/discoverers/cloud_foundry/parser.go
+++ b/pkg/providers/discoverers/cloud_foundry/parser.go
@@ -78,8 +78,8 @@ func parseProcessTemplate(cfApp cfTypes.AppManifest) (*ProcessSpecTemplate, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template spec: %w", err)
 	}
-	if cfApp.Instances == nil {
-		template = ProcessSpecTemplate{Instances: defaultInstanceNumber}
+	if cfApp.Instances == nil || *cfApp.Instances == uint(0) {
+		template.Instances = defaultInstanceNumber
 	}
 	if cfApp.LogRateLimitPerSecond != "" {
 		template.LogRateLimit = cfApp.LogRateLimitPerSecond

--- a/pkg/providers/discoverers/cloud_foundry/parser.go
+++ b/pkg/providers/discoverers/cloud_foundry/parser.go
@@ -62,6 +62,9 @@ func parseProcessInline(cfApp cfTypes.AppManifest) (*ProcessSpec, error) {
 	if cfApp.LogRateLimitPerSecond != "" {
 		processSpec.LogRateLimit = cfApp.LogRateLimitPerSecond
 	}
+	if cfApp.DiskQuota != "" {
+		processSpec.DiskQuota = cfApp.DiskQuota
+	}
 	return &processSpec, nil
 }
 
@@ -79,7 +82,9 @@ func parseProcessTemplate(cfApp cfTypes.AppManifest) (*ProcessSpecTemplate, erro
 	if cfApp.LogRateLimitPerSecond != "" {
 		template.LogRateLimit = cfApp.LogRateLimitPerSecond
 	}
-
+	if cfApp.DiskQuota != "" {
+		template.DiskQuota = cfApp.DiskQuota
+	}
 	return &template, nil
 }
 

--- a/pkg/providers/discoverers/cloud_foundry/provider.go
+++ b/pkg/providers/discoverers/cloud_foundry/provider.go
@@ -550,7 +550,7 @@ func (c *CloudFoundryProvider) getSidecars(appGUID string) (*cfTypes.AppManifest
 			Name:         sc.Name,
 			ProcessTypes: pt,
 			Command:      sc.Command,
-			Memory:       sc.MemoryInMB,
+			Memory:       strconv.Itoa(sc.MemoryInMB),
 		})
 	}
 	return &sidecars, nil

--- a/pkg/providers/discoverers/cloud_foundry/provider.go
+++ b/pkg/providers/discoverers/cloud_foundry/provider.go
@@ -352,7 +352,7 @@ func (c *CloudFoundryProvider) discoverFromManifestFile(filePath string) (*Appli
 		}
 		return &app, nil
 	}
-	c.logger.Printf("Failed to parse Application manifest. Will attempt again using the Cloud Foundry Application manifest: %s", err)
+	c.logger.Info("Failed to parse Application manifest. Will attempt again using the Cloud Foundry Application manifest", "error", err)
 	var cfManifest cfTypes.CloudFoundryManifest
 	if err := yaml.Unmarshal(data, &cfManifest); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal YAML: %v", err)
@@ -360,7 +360,7 @@ func (c *CloudFoundryProvider) discoverFromManifestFile(filePath string) (*Appli
 	if len(cfManifest.Applications) == 0 {
 		return nil, fmt.Errorf("no applications found in %s", filePath)
 	}
-	c.logger.Printf("Found %d applications in manifest in %s", len(cfManifest.Applications), filePath)
+	c.logger.Info("Found applications in manifest", "count", len(cfManifest.Applications), "file", filePath)
 	app, err := parseCFApp(cfManifest.Space, *cfManifest.Applications[0])
 	if err != nil {
 		return nil, err

--- a/pkg/providers/discoverers/cloud_foundry/provider_test.go
+++ b/pkg/providers/discoverers/cloud_foundry/provider_test.go
@@ -990,8 +990,7 @@ var _ = Describe("CloudFoundry Provider", Ordered, func() {
 								},
 							},
 						},
-						Timeout:             60,
-						ProcessSpecTemplate: ProcessSpecTemplate{},
+						Timeout: 60,
 					}
 					processManifestPath := filepath.Join("test_data", "process_manifest", "manifest.yml")
 					app, err := provider.discoverFromManifestFile(processManifestPath)

--- a/pkg/providers/discoverers/cloud_foundry/provider_test.go
+++ b/pkg/providers/discoverers/cloud_foundry/provider_test.go
@@ -1270,7 +1270,7 @@ var _ = Describe("CloudFoundry Provider", Ordered, func() {
 						ProcessSpecTemplate: &ProcessSpecTemplate{
 							Instances: 1,
 						},
-						Timeout: 60,
+						Timeout: 120,
 						Processes: Processes{
 							{
 								Type:    Web,

--- a/pkg/providers/discoverers/cloud_foundry/provider_test.go
+++ b/pkg/providers/discoverers/cloud_foundry/provider_test.go
@@ -1242,7 +1242,12 @@ var _ = Describe("CloudFoundry Provider", Ordered, func() {
 						Routes: RouteSpec{
 							Routes: Routes{
 								{Route: "route.example.com"},
-								{Route: "another-route.example.com"},
+								{Route: "another-route.example.com",
+									Protocol: HTTP2RouteProtocol,
+									Options: RouteOptions{
+										LoadBalancing: LeastConnectionLoadBalancingType,
+									},
+								},
 							},
 						},
 						Services: Services{
@@ -1258,6 +1263,7 @@ var _ = Describe("CloudFoundry Provider", Ordered, func() {
 									"key1": "value1",
 									"key2": "value2",
 								},
+								BindingName: "my-service3",
 							},
 						},
 						Stack: "cflinuxfs3",

--- a/pkg/providers/discoverers/cloud_foundry/test_data/complete-manifest/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/complete-manifest/manifest.yml
@@ -1,0 +1,57 @@
+# taken from https://v3-apidocs.cloudfoundry.org/version/3.76.0/index.html#the-app-manifest-specification
+# added application's name 'name: complete' since it is missing in the example and it
+# is required by the spec: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#minimal-manifest
+---
+applications:
+  - name: complete
+    buildpacks:
+      - ruby_buildpack
+      - java_buildpack
+    env:
+      VAR1: value1
+      VAR2: value2
+    routes:
+      - route: route.example.com
+      - route: another-route.example.com
+    services:
+      - my-service1
+      - my-service2
+      - name: my-service-with-arbitrary-params
+        parameters:
+          key1: value1
+          key2: value2
+    stack: cflinuxfs3
+    metadata:
+      annotations:
+        contact: bob@example.com jane@example.com
+      labels:
+        sensitive: true
+    processes:
+      - type: web
+        command: start-web.sh
+        disk_quota: 512M
+        health-check-http-endpoint: /healthcheck
+        health-check-type: http
+        health-check-invocation-timeout: 10
+        instances: 3
+        memory: 500M
+        timeout: 10
+      - type: worker
+        command: start-worker.sh
+        disk_quota: 1G
+        health-check-type: process
+        instances: 2
+        memory: 256M
+        timeout: 15
+    sidecars:
+      - name: authenticator
+        process_types:
+          - web
+          - worker
+        command: bundle exec run-authenticator
+        memory: 800M
+      - name: upcaser
+        process_types:
+          - worker
+        command: ./tr-server
+        memory: 900M

--- a/pkg/providers/discoverers/cloud_foundry/test_data/complete-manifest/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/complete-manifest/manifest.yml
@@ -13,6 +13,9 @@ applications:
     routes:
       - route: route.example.com
       - route: another-route.example.com
+        protocol: http2
+        options:
+          loadbalancing: "least-connection"
     services:
       - my-service1
       - my-service2
@@ -20,6 +23,7 @@ applications:
         parameters:
           key1: value1
           key2: value2
+        binding_name: my-service3
     stack: cflinuxfs3
     metadata:
       annotations:

--- a/pkg/providers/discoverers/cloud_foundry/test_data/complete-manifest/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/complete-manifest/manifest.yml
@@ -25,6 +25,7 @@ applications:
           key2: value2
         binding_name: my-service3
     stack: cflinuxfs3
+    timeout: 120
     metadata:
       annotations:
         contact: bob@example.com jane@example.com

--- a/pkg/providers/discoverers/cloud_foundry/test_data/hello-spring-cloud/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/hello-spring-cloud/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: hello-spring-cloud
+  instances: 1
+  random-route: true
+  path: target/hello-spring-cloud-0.0.1.BUILD-SNAPSHOT.jar

--- a/pkg/providers/discoverers/cloud_foundry/test_data/inline-process-with-type-only-manifest/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/inline-process-with-type-only-manifest/manifest.yml
@@ -1,0 +1,8 @@
+name: app-with-inline-process-only-type
+disk_quota: 512M
+memory: 500M
+timeout: 10
+docker:
+ image: myregistry/myapp:latest
+ username: docker-registry-user
+type: web

--- a/pkg/providers/discoverers/cloud_foundry/test_data/multiple-processes/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/multiple-processes/manifest.yml
@@ -1,0 +1,22 @@
+---
+applications:
+- name: multiple-processes
+  instances: 1
+  random-route: true
+  processes:
+  - type: web
+    command: start-web.sh
+    disk_quota: 512M
+    health-check-http-endpoint: /healthcheck
+    health-check-type: http
+    health-check-invocation-timeout: 10
+    instances: 3
+    memory: 500M
+    timeout: 10
+  - type: worker
+    command: start-worker.sh
+    disk_quota: 1G
+    health-check-type: process
+    instances: 2
+    memory: 256M
+    timeout: 15

--- a/pkg/providers/discoverers/cloud_foundry/test_data/pong-matcher-sails/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/pong-matcher-sails/manifest.yml
@@ -1,0 +1,5 @@
+---
+applications:
+  - name: sailspong
+    services:
+      - mysql

--- a/pkg/providers/discoverers/cloud_foundry/test_data/process_manifest/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/process_manifest/manifest.yml
@@ -1,0 +1,14 @@
+docker:
+    image: myregistry/myapp:latest
+health-check-type: port
+health-check-http-endpoint: "/"
+health-check-invocation-timeout: 1
+health-check-interval: 30
+memory: 500M
+name: app-with-inline-process
+readiness-health-check-type: process
+readiness-health-check-http-endpoint: "/"
+readiness-health-invocation-timeout: 1
+readiness-health-check-interval: 30
+instances: 1
+type: web

--- a/pkg/providers/discoverers/cloud_foundry/test_data/process_manifest/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/process_manifest/manifest.yml
@@ -1,14 +1,14 @@
 docker:
     image: myregistry/myapp:latest
 health-check-type: port
-health-check-http-endpoint: "/"
-health-check-invocation-timeout: 1
-health-check-interval: 30
+health-check-http-endpoint: "/health"
+health-check-invocation-timeout: 3
+health-check-interval: 90
 memory: 500M
 name: app-with-inline-process
 readiness-health-check-type: process
-readiness-health-check-http-endpoint: "/"
-readiness-health-invocation-timeout: 1
-readiness-health-check-interval: 30
-instances: 1
+readiness-health-check-http-endpoint: "/readiness"
+readiness-health-invocation-timeout: 10
+readiness-health-check-interval: 60
+instances: 2
 type: web

--- a/pkg/providers/discoverers/cloud_foundry/test_data/rails-sample-app/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/rails-sample-app/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+- name: rails-sample
+  random-route: true
+  memory: 256M
+  instances: 1
+  path: .
+  command: bundle exec rake db:migrate && bundle exec rails s -p $PORT
+  services:
+    - rails-postgres

--- a/pkg/providers/discoverers/cloud_foundry/test_data/sidecar-dependant-app/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/sidecar-dependant-app/manifest.yml
@@ -1,0 +1,14 @@
+---
+applications:
+- name: sidecar-dependent-app
+  disk_quota: 1G
+  instances: 1
+  memory: 256M
+  env:
+    CONFIG_SERVER_PORT: 8082
+  stack: cflinuxfs3
+  sidecars:
+  - name: config-server
+    process_types:
+    - web
+    command: './config-server'

--- a/pkg/providers/discoverers/cloud_foundry/test_data/spring-music/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/spring-music/manifest.yml
@@ -1,0 +1,23 @@
+---
+applications:
+  - name: spring-music
+    memory: 1G
+    path: build/libs/spring-music-1.0.jar
+    env:
+      JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
+      SPRING_PROFILES_ACTIVE: http2
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 17.+ } }'
+    disk_quota: 1G
+    instances: 1
+    buildpacks:
+      - java_buildpack
+    routes:
+      - route: rammstein.music
+        protocol: http2
+    services:
+      - mysql
+      - name: gateway
+        parameters:
+          routes: {"path": "/music/**"}
+      - name: lb
+        binding_name: load_balancer

--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -112,6 +112,8 @@ type ProcessSpecTemplate struct {
 	// Lifecycle captures the value fo the lifecycle field in the CF application manifest.
 	// Valid values are `buildpack`, `cnb`, and `docker`. Defaults to `buildpack`
 	Lifecycle LifecycleType `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty" validate:"omitempty,oneof=buildpack cnb docker"`
+	// Timeout represents the time in seconds at which the health-check will report failure.
+	Timeout int `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"omitempty"`
 }
 
 type LifecycleType string

--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -32,6 +32,8 @@ type Application struct {
 	Docker Docker `yaml:"docker,omitempty" json:"docker,omitempty" validate:"omitempty"`
 	// ProcessSpec embeds the process specification details, which are inlined and validated if present.
 	*ProcessSpecTemplate `yaml:",inline" json:",inline" validate:"omitempty"`
+	// Path informs Cloud Foundry the locatino of the directory in which it can find your app.
+	Path string `yaml:"path,omitempty" json:"path,omitempty" validate:"omitempty"`
 }
 
 type Services []ServiceSpec
@@ -51,12 +53,12 @@ type SidecarSpec struct {
 	// ProcessTypes captures the different process types defined for the sidecar.
 	// Compared to a Process, which has only one type, sidecar processes can
 	// accumulate more than one type.
-	ProcessTypes []ProcessType `yaml:"processType" json:"processType" validate:"required,oneof=worker web"`
+	ProcessTypes []ProcessType `yaml:"processType" json:"processType" validate:"required"`
 	// Command captures the command to run the sidecar
 	Command string `yaml:"command" json:"command" validate:"required"`
 	// Memory represents the amount of memory to allocate to the sidecar.
 	// It's an optional field.
-	Memory string `yaml:"memory,omitempty" json:"memory,omitempty"`
+	Memory int `yaml:"memory,omitempty" json:"memory,omitempty"`
 }
 
 type ServiceSpec struct {
@@ -165,14 +167,14 @@ type Route struct {
 	Route string `yaml:"route" json:"route" validate:"required"`
 	// Protocol captures the protocol type: http, http2 or tcp. Note that the CF `protocol` field is only available
 	// for CF deployments that use HTTP/2 routing.
-	Protocol RouteProtocol `yaml:"protocol,omitempty" json:"protocol,omitempty" validate:"oneof=http1 http2 tcp"`
+	Protocol RouteProtocol `yaml:"protocol,omitempty" json:"protocol,omitempty" validate:"omitempty,oneof=http1 http2 tcp"`
 	// Options captures the options for the Route. Only load balancing is supported at the moment.
 	Options RouteOptions `yaml:"options,omitempty" json:"options,omitempty" validate:"omitempty"`
 }
 
 type RouteOptions struct {
 	// LoadBalancing captures the settings for load balancing. Only `round-robin` or `least-connections` are supported
-	LoadBalancing LoadBalancingType `yaml:"loadBalancing,omitempty" json:"loadBalancing,omitempty" validate:"oneof=round-robin least-connections"`
+	LoadBalancing LoadBalancingType `yaml:"loadBalancing,omitempty" json:"loadBalancing,omitempty" validate:"omitempty,oneof=round-robin least-connections"`
 }
 
 type LoadBalancingType string

--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -178,8 +178,9 @@ type Route struct {
 }
 
 type RouteOptions struct {
-	// LoadBalancing captures the settings for load balancing. Only `round-robin` or `least-connections` are supported
-	LoadBalancing LoadBalancingType `yaml:"loadBalancing,omitempty" json:"loadBalancing,omitempty" validate:"omitempty,oneof=round-robin least-connections"`
+	// LoadBalancing captures the settings for load balancing. Only `round-robin` or `least-connection` are supported
+	// https://v3-apidocs.cloudfoundry.org/version/3.192.0/index.html#the-route-options-object
+	LoadBalancing LoadBalancingType `yaml:"loadBalancing,omitempty" json:"loadBalancing,omitempty" validate:"omitempty,oneof=round-robin least-connection"`
 }
 
 type LoadBalancingType string

--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -31,7 +31,7 @@ type Application struct {
 	// Docker captures the Docker specification in the CF application manifest.
 	Docker Docker `yaml:"docker,omitempty" json:"docker,omitempty" validate:"omitempty"`
 	// ProcessSpec embeds the process specification details, which are inlined and validated if present.
-	ProcessSpecTemplate `yaml:",inline" json:",inline" validate:"omitempty"`
+	*ProcessSpecTemplate `yaml:",inline" json:",inline" validate:"omitempty"`
 }
 
 type Services []ServiceSpec

--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -56,8 +56,11 @@ type SidecarSpec struct {
 	ProcessTypes []ProcessType `yaml:"processType" json:"processType" validate:"required"`
 	// Command captures the command to run the sidecar
 	Command string `yaml:"command" json:"command" validate:"required"`
-	// Memory represents the amount of memory to allocate to the sidecar.
+	// Memory represents the amount of memory in MB to allocate to the sidecar.
+	// Reference: https://v3-apidocs.cloudfoundry.org/version/3.192.0/index.html#the-sidecar-object
 	// It's an optional field.
+	// In the CF documentation it is referenced as an int when retrieving from a running application (live connection)
+	// but it is defined as a string (e.g: '800MB') in a manifest file.
 	Memory int `yaml:"memory,omitempty" json:"memory,omitempty"`
 }
 
@@ -90,7 +93,9 @@ type Metadata struct {
 type ProcessSpec struct {
 	// Type captures the `type` field in the Process specification.
 	// Accepted values are `web` or `worker`
-	Type                ProcessType `yaml:"type" json:"type" validate:"required,oneof=web worker"`
+	Type ProcessType `yaml:"type" json:"type" validate:"required,oneof=web worker"`
+	// Timeout represents the time in seconds at which the health-check will report failure.
+	Timeout             int `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"omitempty"`
 	ProcessSpecTemplate `yaml:",inline" json:",inline" validate:"omitempty"`
 }
 
@@ -112,8 +117,6 @@ type ProcessSpecTemplate struct {
 	// Lifecycle captures the value fo the lifecycle field in the CF application manifest.
 	// Valid values are `buildpack`, `cnb`, and `docker`. Defaults to `buildpack`
 	Lifecycle LifecycleType `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty" validate:"omitempty,oneof=buildpack cnb docker"`
-	// Timeout represents the time in seconds at which the health-check will report failure.
-	Timeout int `yaml:"timeout,omitempty" json:"timeout,omitempty" validate:"omitempty"`
 }
 
 type LifecycleType string


### PR DESCRIPTION
@gciavarrini PTAL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for parsing health and readiness probes from inline and template process specifications.
  * Enhanced manifest parsing to separately handle template and inline processes, with added disk quota support.
  * Added validation and parsing logic for sidecars and services in application manifests.
  * Added optional application path field and relaxed validation on route protocols and load balancing options.
  * Added fallback parsing for multi-application manifests alongside single-application manifests.

* **Tests**
  * Expanded test coverage with new cases for diverse manifest configurations including probes, sidecars, services, and multiple processes.
  * Added multiple new manifest files as test data covering various application setups and resource configurations.

* **Refactor**
  * Modularized process spec parsing and restructured main parsing logic for clarity.
  * Changed application struct to use pointer embedding for process spec templates.
  * Adjusted sidecar memory handling from string to integer with explicit conversion and validation.
  * Loosened validation constraints on sidecar process types and route/load balancing fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->