### PR TITLE
set metadata field as inline

### DIFF
--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -4,7 +4,7 @@ package cloud_foundry
 // the information it contains has been processed to simplify its transformation to a Kubernetes manifest using MTA
 type Application struct {
 	// Metadata captures the name, labels and annotations in the application.
-	Metadata Metadata `yaml:",inline" json:",inline" validate:"required"`
+	Metadata `yaml:",inline" json:",inline" validate:"required"`
 	// Env captures the `env` field values in the CF application manifest.
 	Env map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 	// Routes represent the routes that are made available by the application.


### PR DESCRIPTION
Metadata field is set as inline in yaml and json tag.
```go
// Metadata captures the name, labels and annotations in the application.
Metadata `yaml:",inline" json:",inline" validate:"required"`
```

This PR changes the discover manifest from 

```yaml
Metadata:
    annotations:
        contact: bob@example.com jane@example.com
    labels:
        sensitive: "true"
    name: app-with-metadata
```
to 
```yaml
name: app-with-metadata
metadata:
  annotations:
    contact: "bob@example.com jane@example.com"
  labels:
    sensitive: true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved struct design for easier access to application metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->