### PR TITLE
CF local installation: only supported on bare-metal Fedora 41

### DIFF
--- a/docs/deploying-cf-locally.md
+++ b/docs/deploying-cf-locally.md
@@ -3,6 +3,9 @@ Deploying Cloud Foundry with Bosh-Lite is a low-cost, lightweight approach tailo
 
 > 💡 Note: This environment is not production-grade.
 
+> ⚠️ Important: This setup only works on bare-metal Fedora 41.<br/>
+> Installing it on a VM or a virtualized host does not work and is not supported.
+
 ## Install VirtualBox and prerequisites
  
 Ensure that VirtualBox and its extension pack are installed and configured


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to clarify that setup is only supported on bare-metal Fedora 41 and will not work on virtual machines or virtualized hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->