### PR TITLE
Add 'features' attribute to CF Application spec

### DIFF
--- a/internal/models/cf_types.go
+++ b/internal/models/cf_types.go
@@ -49,8 +49,9 @@ type AppManifest struct {
 	Processes          *AppManifestProcesses `yaml:"processes,omitempty"`
 	Stack              string                `yaml:"stack,omitempty"`
 	Metadata           *AppMetadata          `yaml:"metadata,omitempty"`
+	Path               string                `yaml:"path,omitempty"`
+	Features           map[string]bool       `yaml:"features,omitempty"`
 	AppManifestProcess `yaml:",inline"`
-	Path               string `yaml:"path,omitempty"`
 }
 
 type AppManifestProcesses []AppManifestProcess

--- a/pkg/providers/discoverers/cloud_foundry/parser.go
+++ b/pkg/providers/discoverers/cloud_foundry/parser.go
@@ -309,6 +309,7 @@ var parseCFApp = func(spaceName string, cfApp cfTypes.AppManifest) (Application,
 		Docker:              docker,
 		Sidecars:            sidecars,
 		Processes:           processes,
+		Features:            cfApp.Features,
 		Path:                cfApp.Path,
 		ProcessSpecTemplate: &ProcessSpecTemplate{Instances: defaultInstanceNumber},
 	}

--- a/pkg/providers/discoverers/cloud_foundry/provider_test.go
+++ b/pkg/providers/discoverers/cloud_foundry/provider_test.go
@@ -1087,6 +1087,28 @@ var _ = Describe("CloudFoundry Provider", Ordered, func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(app).To(BeEquivalentTo(&expected))
 				})
+				It("validates the discovery data of an app with features", func() {
+					expected := Application{
+						Metadata: Metadata{Name: "app-features"},
+						ProcessSpecTemplate: &ProcessSpecTemplate{
+							Instances: 1,
+						},
+						Routes: RouteSpec{
+							NoRoute: true,
+						},
+						Timeout: 60,
+						Features: map[string]bool{
+							"ssh":                      true,
+							"revisions":                true,
+							"service-binding-k8s":      false,
+							"file-based-vcap-services": false,
+						},
+					}
+					processManifestPath := filepath.Join("test_data", "app-features", "manifest.yml")
+					app, err := provider.discoverFromManifestFile(processManifestPath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(app).To(BeEquivalentTo(&expected))
+				})
 				It("validates the discovery data of an app with a sidecar", func() {
 					expected := Application{
 						Metadata: Metadata{Name: "sidecar-dependent-app"},

--- a/pkg/providers/discoverers/cloud_foundry/test_data/app-features/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/app-features/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: app-features
+  no-route: true
+  features:
+    ssh: true
+    revisions: true
+    service-binding-k8s: false
+    file-based-vcap-services: false

--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -34,6 +34,8 @@ type Application struct {
 	*ProcessSpecTemplate `yaml:",inline" json:",inline" validate:"omitempty"`
 	// Path informs Cloud Foundry the locatino of the directory in which it can find your app.
 	Path string `yaml:"path,omitempty" json:"path,omitempty" validate:"omitempty"`
+	// Feature represents a map of key/value pairs of the app feature names to boolean values indicating whether the feature is enabled or not
+	Features map[string]bool `yaml:"features,omitempty" json:"features,omitempty" validate:"omitempty"`
 }
 
 type Services []ServiceSpec
@@ -105,7 +107,7 @@ type ProcessSpecTemplate struct {
 	// DiskQuota represents the amount of persistent disk requested by the process.
 	DiskQuota string `yaml:"disk,omitempty" json:"disk,omitempty" validate:"omitempty"`
 	// Memory represents the amount of memory requested by the process.
-	Memory string `yaml:"memory" json:"memory" validate:"omitempty"`
+	Memory string `yaml:"memory,omitempty" json:"memory,omitempty" validate:"omitempty"`
 	// HealthCheck captures the health check information
 	HealthCheck ProbeSpec `yaml:"healthCheck,omitempty" json:"healthCheck,omitempty" validate:"omitempty"`
 	// ReadinessCheck captures the readiness check information.


### PR DESCRIPTION
- **Add test to validate probes are properly parsed with inline processes**
- **Reference the ProcessSpecTemplate inline field in CF Application as pointer to avoid generating an empty reference when marshaling the YAML when the field is empty**
- **Add another unit test to cover for probe in an inline process with no probe spec defined**
- **Added unit tests to cover discovery manifests and fixed parsing issues in sidecars, routes and services**
- **Fix CF parse process function and add unit test with 2 processes**
- **Add complete manifest test and changed sidecar memory type from int to string because the CF file manifest is exampled as a string ('800M' or '800MB') but the spec states it's an int**
- **Add route options and binding name use cases to the complete manifest example**
- **Use timeout 120 in complete example to override default value**
- **Fixes due to code rebase and suggestions**
- **Add 'features' attribute to CF Application spec**
