### PR TITLE
Add 'features' attribute to CF Application spec

### DIFF
--- a/internal/models/cf_types.go
+++ b/internal/models/cf_types.go
@@ -49,8 +49,9 @@ type AppManifest struct {
 	Processes          *AppManifestProcesses `yaml:"processes,omitempty"`
 	Stack              string                `yaml:"stack,omitempty"`
 	Metadata           *AppMetadata          `yaml:"metadata,omitempty"`
+	Path               string                `yaml:"path,omitempty"`
+	Features           map[string]bool       `yaml:"features,omitempty"`
 	AppManifestProcess `yaml:",inline"`
-	Path               string `yaml:"path,omitempty"`
 }
 
 type AppManifestProcesses []AppManifestProcess

--- a/pkg/providers/discoverers/cloud_foundry/parser.go
+++ b/pkg/providers/discoverers/cloud_foundry/parser.go
@@ -309,6 +309,7 @@ var parseCFApp = func(spaceName string, cfApp cfTypes.AppManifest) (Application,
 		Docker:              docker,
 		Sidecars:            sidecars,
 		Processes:           processes,
+		Features:            cfApp.Features,
 		Path:                cfApp.Path,
 		ProcessSpecTemplate: &ProcessSpecTemplate{Instances: defaultInstanceNumber},
 	}

--- a/pkg/providers/discoverers/cloud_foundry/provider_test.go
+++ b/pkg/providers/discoverers/cloud_foundry/provider_test.go
@@ -1087,6 +1087,28 @@ var _ = Describe("CloudFoundry Provider", Ordered, func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(app).To(BeEquivalentTo(&expected))
 				})
+				It("validates the discovery data of an app with features", func() {
+					expected := Application{
+						Metadata: Metadata{Name: "app-features"},
+						ProcessSpecTemplate: &ProcessSpecTemplate{
+							Instances: 1,
+						},
+						Routes: RouteSpec{
+							NoRoute: true,
+						},
+						Timeout: 60,
+						Features: map[string]bool{
+							"ssh":                      true,
+							"revisions":                true,
+							"service-binding-k8s":      false,
+							"file-based-vcap-services": false,
+						},
+					}
+					processManifestPath := filepath.Join("test_data", "app-features", "manifest.yml")
+					app, err := provider.discoverFromManifestFile(processManifestPath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(app).To(BeEquivalentTo(&expected))
+				})
 				It("validates the discovery data of an app with a sidecar", func() {
 					expected := Application{
 						Metadata: Metadata{Name: "sidecar-dependent-app"},

--- a/pkg/providers/discoverers/cloud_foundry/test_data/app-features/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/app-features/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: app-features
+  no-route: true
+  features:
+    ssh: true
+    revisions: true
+    service-binding-k8s: false
+    file-based-vcap-services: false

--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -34,6 +34,8 @@ type Application struct {
 	*ProcessSpecTemplate `yaml:",inline" json:",inline" validate:"omitempty"`
 	// Path informs Cloud Foundry the locatino of the directory in which it can find your app.
 	Path string `yaml:"path,omitempty" json:"path,omitempty" validate:"omitempty"`
+	// Feature represents a map of key/value pairs of the app feature names to boolean values indicating whether the feature is enabled or not
+	Features map[string]bool `yaml:"features,omitempty" json:"features,omitempty" validate:"omitempty"`
 }
 
 type Services []ServiceSpec


### PR DESCRIPTION
@gciavarrini PTAL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and displaying application feature flags from Cloud Foundry manifests.
  * Applications now show enabled or disabled features as specified in the manifest.

* **Tests**
  * Added test coverage to verify correct detection and representation of application feature flags in manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->