### PR TITLE
Skip task processes attached to apps

### DIFF
--- a/internal/models/cf_types.go
+++ b/internal/models/cf_types.go
@@ -15,6 +15,7 @@ type AppProcessType string
 const (
 	WebAppProcessType    AppProcessType = "web"
 	WorkerAppProcessType AppProcessType = "worker"
+	TaskAppProcessType   AppProcessType = "task"
 )
 
 type AppRouteProtocol string

--- a/pkg/providers/discoverers/cloud_foundry/parser.go
+++ b/pkg/providers/discoverers/cloud_foundry/parser.go
@@ -47,10 +47,10 @@ func processProcessProbes(cfProcess cfTypes.AppManifestProcess) (HealthCheckSpec
 	return healthCheck, readinessCheck
 }
 func parseProcess(cfApp cfTypes.AppManifestProcess) (*ProcessSpec, error) {
-	if string(cfApp.Type) == string(Task) {
+	if cfApp.Type == cfTypes.TaskAppProcessType {
 		return nil, nil
 	}
-	if string(cfApp.Type) != string(Web) && string(cfApp.Type) != string(Worker) {
+	if cfApp.Type != cfTypes.WebAppProcessType && cfApp.Type != cfTypes.WorkerAppProcessType {
 		return nil, fmt.Errorf("unknown process type %s", cfApp.Type)
 	}
 	processSpec, err := marshalUnmarshal[ProcessSpec](cfApp)

--- a/pkg/providers/discoverers/cloud_foundry/parser.go
+++ b/pkg/providers/discoverers/cloud_foundry/parser.go
@@ -47,6 +47,9 @@ func processProcessProbes(cfProcess cfTypes.AppManifestProcess) (HealthCheckSpec
 	return healthCheck, readinessCheck
 }
 func parseProcess(cfApp cfTypes.AppManifestProcess) (*ProcessSpec, error) {
+	if string(cfApp.Type) == string(Task) {
+		return nil, nil
+	}
 	if string(cfApp.Type) != string(Web) && string(cfApp.Type) != string(Worker) {
 		return nil, fmt.Errorf("unknown process type %s", cfApp.Type)
 	}
@@ -284,6 +287,9 @@ func parseProcesses(cfProcs *cfTypes.AppManifestProcesses) (Processes, error) {
 		p, err := parseProcess(proc)
 		if err != nil {
 			return nil, err
+		}
+		if p == nil {
+			continue
 		}
 		procs = append(procs, *p)
 	}

--- a/pkg/providers/discoverers/cloud_foundry/test_data/multiple-processes/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/multiple-processes/manifest.yml
@@ -19,3 +19,7 @@ applications:
     health-check-type: process
     instances: 2
     memory: 256M
+  - type: task
+    command: run-task.sh
+    instances: 0
+    memory: 128M

--- a/pkg/providers/discoverers/cloud_foundry/types.go
+++ b/pkg/providers/discoverers/cloud_foundry/types.go
@@ -126,6 +126,8 @@ const (
 	Web ProcessType = "web"
 	// Worker represents a `worker` application type
 	Worker ProcessType = "worker"
+	// Task represents a `task` sidecar for an application
+	Task ProcessType = "task"
 )
 
 type ProbeSpec struct {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes during Cloud Foundry app discovery by skipping task-type processes and safely handling nil process entries.
  * Task-type entries in Cloud Foundry manifests are now ignored during discovery, avoiding empty or erroneous results and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

this is due to a bug in cloud foundry returning tasks as a part of the procceses attached to the application