### PR TITLE
Add unit test to validate that only mandatory fields are included in the marshalled discovery manifest for an CF app with only name

### DIFF
--- a/pkg/providers/discoverers/cloud_foundry/provider_test.go
+++ b/pkg/providers/discoverers/cloud_foundry/provider_test.go
@@ -1756,6 +1756,31 @@ applications: []`
 				Expect(b).To(MatchYAML(`name: app-routes`))
 			})
 		})
+
+		Context("validating that only default values are included in an app with only name", func() {
+			It("marshals only mandatory defaults for a minimal app", func() {
+				nopLogger := logr.New(logr.Discard().GetSink())
+				provider := &CloudFoundryProvider{
+					logger: &nopLogger,
+				}
+				app, err := provider.discoverFromManifestFile(filepath.Join("test_data", "basic-app", "manifest.yml"))
+				Expect(err).To(BeNil())
+				out, err := yaml.Marshal(app)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(MatchYAML(`name: basic-app
+processes:
+    - type: web
+      healthCheck:
+        invocationTimeout: 1
+        interval: 30
+        type: port
+        timeout: 60
+      readinessCheck:
+        type: process
+      instances: 1
+`))
+			})
+		})
 		Context("validating health fields are omitted with default values for YAML", func() {
 			It("omits the fields when unset", func() {
 				app := Application{

--- a/pkg/providers/discoverers/cloud_foundry/test_data/basic-app/manifest.yml
+++ b/pkg/providers/discoverers/cloud_foundry/test_data/basic-app/manifest.yml
@@ -1,0 +1,3 @@
+---
+applications:
+- name: basic-app


### PR DESCRIPTION
Signed-off-by: Jordi Gil <jgil@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying default settings are applied when an app manifest contains only a name (ensures default web process, health and readiness checks, and instance count).
  * Added minimal manifest test data to support the new scenario.
  * No production behavior changes; increases confidence and stability by exercising default-value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->