### PR TITLE
Add iptables alternative to SSH tunneling for remote CF access

### DIFF
--- a/docs/deploying-cf-locally.md
+++ b/docs/deploying-cf-locally.md
@@ -487,7 +487,7 @@ Commercial support is available at
     ```
 
 2. Set up ssh tunnel
-   * Share you _**public**_ ssh key with the remote system admin.
+   * Share your _**public**_ ssh key with the remote system admin.
    * Once access is granted, verify your SSH connection:
 
       ```bash
@@ -527,6 +527,12 @@ As an alternative to SSH tunneling, you can use iptables rules for persistent po
     sudo iptables -t nat -A PREROUTING -p tcp --dport 8443 -j DNAT --to-destination 10.244.0.34:443
     sudo iptables -t nat -A PREROUTING -p tcp --dport 8444 -j DNAT --to-destination 10.244.0.131:443
     sudo iptables -t nat -A POSTROUTING -d 10.244.0.0/16 -j MASQUERADE
+    
+    # Enable forwarded traffic via filter table
+    sudo iptables -A FORWARD -p tcp -d 10.244.0.131 --dport 443 \
+      -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
+    sudo iptables -A FORWARD \
+      -m state --state ESTABLISHED,RELATED -j ACCEPT
     ```
 
 3. Enable IP forwarding in the kernel:


### PR DESCRIPTION
docs: Add iptables alternative to SSH tunneling for remote CF access



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded “Connect to a remote Cloud Foundry instance” with two user-facing methods: SSH tunnel (local host mappings, step-by-step setup) and an iptables NAT alternative (persistent network forwarding).
  - Reordered steps and updated verification flow, including explicit cf login guidance.
  - Added runnable command blocks and notes on trade-offs: SSH is ephemeral; NAT persists across reboots but requires initial access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->