### PR TITLE
:bug: Add workarounds

### DIFF
--- a/docs/deploying-cf-locally.md
+++ b/docs/deploying-cf-locally.md
@@ -52,7 +52,7 @@ sudo systemctl restart systemd-resolved
 sudo firewall-cmd --new-zone=vboxnet --permanent
 sudo firewall-cmd --reload
 sudo firewall-cmd --zone=vboxnet --change-interface=vboxnet0
-sudo firewall-cmd --zone vboxnet --add-service dns
+sudo firewall-cmd --zone=vboxnet --add-service=dns
 sudo firewall-cmd --runtime-to-permanent
 ```
 
@@ -91,6 +91,7 @@ mv ./bosh-cli-7.9.8-linux-amd64 ~/.local/bin/bosh
 
 ```bash
 git clone https://github.com/cloudfoundry/bosh-deployment ~/workspace/bosh-deployment
+pushd ~/workspace/bosh-deployment; git reset --hard 4e030b34f3ea6dae68262346c2c45dbd55f02499; popd
 mkdir -p ~/deployments/vbox
 cd ~/deployments/vbox
 ```
@@ -216,6 +217,7 @@ bosh -e vbox update-runtime-config ~/workspace/bosh-deployment/runtime-configs/d
 ```bash
 git clone https://github.com/cloudfoundry/cf-deployment.git ~/cf-deployment
 cd ~/cf-deployment
+git reset --hard v51.2.0
 ```
 
 To ensure you're using the latest precompiled stemcell version, first check which version is referenced in the `operations/use-compiled-releases.yml` file:


### PR DESCRIPTION
While helping @senthilredhat to deploy Cloud Foundry we discovered that neither of us had functioning DNS on 10.0.2.1. I was able to come up with the following process to enable DNS on the second interface as an alternative.

In addition several of the steps in our setup assume the OS version is Ubuntu Jammy, but Bosh has switched to deploying Ubuntu Noble by default. This brings in changes, like a switch to systemd-resolved and a chance in the local link address which bosh-dns uses to serve DNS from 169.254.0.2 to 169.254.0.35 leading to more DNS breakages and other issues. I will be opening an issue to track updating our instructions for using the current code so we can (hopefully) unpin these.

For now using SHAs we used when the instructions were written continues to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Alternate DNS” section with steps to work around VirtualBox NAT DNS limitations (system resolver and firewall guidance).
  * Added DNS override instructions into the local BOSH-Lite deployment flow and adjusted deployment narration to reflect DNS overrides.
  * Documented pinning the CF deployment source to a fixed release/version for reproducible local deployments and made this explicit wherever the deployment is cloned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->